### PR TITLE
ability to change site name instead of default Piccolo

### DIFF
--- a/admin_ui/src/components/NavBar.vue
+++ b/admin_ui/src/components/NavBar.vue
@@ -12,7 +12,8 @@
 
             <h1>
                 <router-link to="/">
-                    <font-awesome-icon icon="tools" />Piccolo Admin
+                    <font-awesome-icon icon="tools" />
+                    {{ siteName }} Admin
                 </router-link>
             </h1>
 
@@ -53,7 +54,7 @@ export default Vue.extend({
     data() {
         return {
             showSidebar: false,
-            showDropdown: false
+            showDropdown: false,
         }
     },
     computed: {
@@ -63,12 +64,18 @@ export default Vue.extend({
         username() {
             let user = this.$store.state.user
             return user ? user.username : "Unknown"
-        }
+        },
+        siteName() {
+            return this.$store.state.sitename.sitename
+        },
     },
     components: {
         SidebarOverlay,
-        NavDropDownMenu
-    }
+        NavDropDownMenu,
+    },
+    async created() {
+        await this.$store.dispatch("fetchSiteName")
+    },
 })
 </script>
 

--- a/admin_ui/src/store.ts
+++ b/admin_ui/src/store.ts
@@ -26,9 +26,13 @@ export default new Vuex.Store({
         selectedRow: undefined,
         sortBy: null as i.SortByConfig | null,
         tableNames: [],
-        user: undefined
+        user: undefined,
+        sitename: {}
     },
     mutations: {
+        updateSiteName(state, value) {
+            state.sitename = value
+        },
         updateTableNames(state, value) {
             state.tableNames = value
         },
@@ -77,6 +81,10 @@ export default new Vuex.Store({
         }
     },
     actions: {
+        async fetchSiteName(context) {
+            const response = await axios.get(`${BASE_URL}sitename/`)
+            context.commit('updateSiteName', response.data)
+        },
         async fetchTableNames(context) {
             const response = await axios.get(`${BASE_URL}tables/`)
             context.commit('updateTableNames', response.data)

--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -58,8 +58,10 @@ class AdminRouter(Router):
         read_only: bool = False,
         rate_limit_provider: t.Optional[RateLimitProvider] = None,
         production: bool = False,
+        sitename: str = "Piccolo",
     ) -> None:
         self.auth_table = auth_table
+        self.sitename = sitename
 
         with open(os.path.join(ASSET_PATH, "index.html")) as f:
             self.template = f.read()
@@ -149,6 +151,14 @@ class AdminRouter(Router):
                                 )
                             ),
                         ),
+                        Mount(
+                            path="/sitename/",
+                            app=auth_middleware(
+                                Router(
+                                    [Route(path="/", endpoint=self.get_sitename)]
+                                )
+                            ),
+                        ),
                     ]
                 ),
             ),
@@ -179,6 +189,11 @@ class AdminRouter(Router):
 
     def get_table_list(self, request: Request) -> JSONResponse:
         return JSONResponse([i._meta.tablename for i in self.tables])
+
+    ###########################################################################
+
+    def get_sitename(self, request: Request) -> JSONResponse:
+        return JSONResponse({"sitename": self.sitename})
 
 
 def get_all_tables(
@@ -218,6 +233,7 @@ def create_admin(
     read_only: bool = False,
     rate_limit_provider: t.Optional[RateLimitProvider] = None,
     production: bool = False,
+    sitename: str = "Piccolo",
     auto_include_related: bool = True,
     allowed_hosts: t.Sequence[str] = [],
 ):
@@ -253,6 +269,8 @@ def create_admin(
         If True, the admin will enforce stronger security - for example,
         the cookies used will be secure, meaning they are only sent over
         HTTPS.
+    :param sitename:
+        Specify a different site name in admin UI (default Piccolo Admin)
     :param auto_include_related:
         If a table has foreign keys to other tables, those tables will also be
         included in the admin by default, if not already specified. Otherwise
@@ -279,6 +297,7 @@ def create_admin(
                 read_only=read_only,
                 rate_limit_provider=rate_limit_provider,
                 production=production,
+                sitename=sitename,
             ),
             allowed_hosts=allowed_hosts,
         )


### PR DESCRIPTION
Hi Daniel
here is my attempt to add ability to change site name instead of the default `Piccolo Admin` in `create_admin`. Cheers.