### PR TITLE
minor meta fix

### DIFF
--- a/admin_ui/src/modules/meta.ts
+++ b/admin_ui/src/modules/meta.ts
@@ -8,18 +8,18 @@ export default {
         piccoloAdminVersion: 'Unknown'
     },
     mutations: {
-        updateSiteName(state, value: Object) {
+        updateSiteName(state, value: string) {
             state.siteName = value
         },
-        updatePiccoloAdminVersion(state, value: Object) {
+        updatePiccoloAdminVersion(state, value: string) {
             state.piccoloAdminVersion = value
         },
     },
     actions: {
         async fetchMeta(context) {
             const response = await axios.get(`${BASE_URL}meta/`)
-            this.commit('updateSiteName', response.data.site_name)
-            this.commit('updatePiccoloAdminVersion', response.data.piccolo_admin_version)
+            context.commit('updateSiteName', response.data.site_name)
+            context.commit('updatePiccoloAdminVersion', response.data.piccolo_admin_version)
         }
     }
 }

--- a/admin_ui/src/views/Home.vue
+++ b/admin_ui/src/views/Home.vue
@@ -22,6 +22,9 @@ export default {
     mounted() {
         this.$store.commit("updateCurrentTablename", "")
     },
+    async created() {
+        await this.$store.dispatch("fetchMeta")
+    },
 }
 </script>
 


### PR DESCRIPTION
@dantownsend Minor fixes for a custom site name because metadata doesn't display properly until the page refreshes. You can see that in [demo](https://demo1.piccolo-orm.com/#/login?nextURL=%2F), version in the modal is `Unknown` until you refresh the page. With these changes, everything should be fine with the first page view (at least that's the case with me), but you check it out. Cheers.