### PR TITLE
updated example.py to use targ and to support postgres

### DIFF
--- a/piccolo_admin/sandbox.py
+++ b/piccolo_admin/sandbox.py
@@ -2,17 +2,18 @@
 Runs the admin in read only mode - useful for letting people evaluate the admin
 online without risk of abuse.
 """
-import sys
-
-import uvicorn
 from piccolo_admin.example import (
     Director,
     Movie,
     Sessions,
     User,
     create_admin,
+    create_schema,
     populate_data,
+    set_engine,
 )
+import targ
+import uvicorn
 
 
 APP = create_admin(
@@ -20,15 +21,25 @@ APP = create_admin(
 )
 
 
-def main(host="localhost", port=8080):
+def run(host="localhost", port=8080):
+    set_engine()
+    create_schema(persist=False)
     populate_data()
     uvicorn.run(APP, host=host, port=port)
 
 
-if __name__ == "__main__":
-    args = sys.argv
+def sandbox(production: bool = False):
+    """
+    Run the Piccolo Admin in read only mode with a SQLite database.
+    """
     kwargs = {}
-    if "--production" in args:
+    if production:
         kwargs.update({"host": "0.0.0.0", "port": 80})
 
-    main(**kwargs)
+    run(**kwargs)
+
+
+if __name__ == "__main__":
+    cli = targ.CLI()
+    cli.register(sandbox)
+    cli.run(solo=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ piccolo_api>=0.11.0
 uvicorn
 aiofiles>=0.5.0
 Hypercorn
+targ>=0.1.9


### PR DESCRIPTION
`example.py` can now run using Postgres, as well as SQLite. This is very useful for testing if new column types work with the admin.

The CLI for `example.py` and `sandbox.py` were also converted to use targ, rather than `sys.argv`.