### PR TITLE
small underscore fix

### DIFF
--- a/admin_ui/src/components/AddRowForm.vue
+++ b/admin_ui/src/components/AddRowForm.vue
@@ -4,8 +4,14 @@
 
         <pre>{{ errors }}</pre>
 
-        <form v-if="defaults" v-on:submit.prevent="submitForm($event)">
-            <RowForm v-bind:row="defaults" v-bind:schema="schema" />
+        <form
+            v-if="defaults"
+            v-on:submit.prevent="submitForm($event)"
+        >
+            <RowForm
+                v-bind:row="defaults"
+                v-bind:schema="schema"
+            />
             <button>Create</button>
         </form>
     </div>
@@ -36,7 +42,7 @@ export default {
 
             const json = {}
             for (const i of form.entries()) {
-                json[i[0]] = i[1]
+                json[i[0].split(" ").join("_")] = i[1]
             }
             try {
                 await this.$store.dispatch("createRow", {


### PR DESCRIPTION
Small fix when column name contains underscore in Schema definition. 

```
class Task(Table):
    """
    An Task table.
    """

    name = Varchar()
    description = Text()
    completed = Boolean(default=False)
    task_user = ForeignKey(references=BaseUser) # <- like this underscore 
```

With this change column content will display correctly in piccolo admin after creation.