### PR TITLE
fix clear filters for duration widget

### DIFF
--- a/admin_ui/src/components/RowFilter.vue
+++ b/admin_ui/src/components/RowFilter.vue
@@ -80,10 +80,32 @@ export default Vue.extend({
         },
         async clearFilters() {
             console.log("Clearing ...")
-            let form: HTMLFormElement = this.$refs.form
+            let form: any = this.$refs.form
+
+            let elements = form.elements
             form.reset()
+
+            for (let i = 0; i < elements.length; i++) {
+                let field_type = elements[i].type
+
+                switch (field_type) {
+                    case "text":
+                    case "textarea":
+                    case "hidden":
+                        elements[i].value = ""
+                        break
+                    case "select-one":
+                        elements[i].selectedIndex = 0
+                        break
+
+                    default:
+                        break
+                }
+            }
+
             this.$store.commit("updateFilterParams", {})
             this.$store.commit("updateCurrentPageNumber", 1)
+
             try {
                 await this.$store.dispatch("fetchRows")
             } catch (error) {

--- a/admin_ui/src/components/RowFilter.vue
+++ b/admin_ui/src/components/RowFilter.vue
@@ -81,27 +81,13 @@ export default Vue.extend({
         async clearFilters() {
             console.log("Clearing ...")
             let form: any = this.$refs.form
-
-            let elements = form.elements
-            form.reset()
-
-            for (let i = 0; i < elements.length; i++) {
-                let field_type = elements[i].type
-
-                switch (field_type) {
-                    case "text":
-                    case "textarea":
-                    case "hidden":
-                        elements[i].value = ""
-                        break
-                    case "select-one":
-                        elements[i].selectedIndex = 0
-                        break
-
-                    default:
-                        break
+            let elements = [...form.elements].forEach((element) => {
+                if (element.type == "hidden") {
+                    element.value = ""
                 }
-            }
+            })
+
+            form.reset()
 
             this.$store.commit("updateFilterParams", {})
             this.$store.commit("updateCurrentPageNumber", 1)


### PR DESCRIPTION
Small fix for clear filters in `RowFilter.vue`. Duration widget are not properly cleaned. Now all fields is properly cleaned.