### PR TITLE
added `inflate` option to example.py, for generating lots of dummy data

### DIFF
--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -30,5 +30,11 @@ The UI needs an API to interact with - the easiest way to do this is to use the 
     # Or alternatively
     python -m piccolo_admin.example
 
+    # You can also populate lots of test data
+    python -m piccolo_admin.example --inflate=10000
+
+    # To find out all available options:
+    python -m piccolo_admin.example --help
+
 
 You will need to configure a local webserver as a proxy - see extra/piccolo_admin.

--- a/piccolo_admin/example_data.py
+++ b/piccolo_admin/example_data.py
@@ -274,3 +274,36 @@ MOVIES = [
         "box_office": Decimal("956.0"),
     },
 ]
+
+
+# Some random words used to generate fake movie names.
+MOVIE_WORDS = [
+    "Adventure",
+    "Alien",
+    "Armageddon",
+    "Android",
+    "Bridge",
+    "Captain",
+    "Destruction",
+    "Evolution",
+    "Extreme",
+    "Fantasy",
+    "Friend",
+    "Galaxy",
+    "King",
+    "Lord",
+    "Master",
+    "Max",
+    "Mutant",
+    "Outpost",
+    "Partner",
+    "Phantom",
+    "Power",
+    "Returns",
+    "Revenge",
+    "Robot",
+    "Star",
+    "Throne",
+    "Thunder",
+    "Twin",
+]

--- a/setup.py
+++ b/setup.py
@@ -10,41 +10,40 @@ from piccolo_admin import __VERSION__ as VERSION
 directory = os.path.abspath(os.path.dirname(__file__))
 
 
-with open(os.path.join(directory, 'requirements.txt')) as f:
+with open(os.path.join(directory, "requirements.txt")) as f:
     contents = f.read()
-    REQUIREMENTS = [i.strip() for i in contents.strip().split('\n')]
+    REQUIREMENTS = [i.strip() for i in contents.strip().split("\n")]
 
 
-with open(os.path.join(directory, 'README.md')) as f:
+with open(os.path.join(directory, "README.md")) as f:
     LONG_DESCRIPTION = f.read()
 
 
 setup(
-    name='piccolo_admin',
+    name="piccolo_admin",
     version=VERSION,
-    description='A simple and powerful admin for Piccolo models, using ASGI.',
+    description="A simple and powerful admin for Piccolo models, using ASGI.",
     long_description=LONG_DESCRIPTION,
-    long_description_content_type='text/markdown',
-    author='Daniel Townsend',
-    author_email='dan@dantownsend.co.uk',
-    python_requires='>=3.7.0',
-    url='https://github.com/piccolo-orm/piccolo_admin',
-    packages=find_packages(exclude=('tests',)),
+    long_description_content_type="text/markdown",
+    author="Daniel Townsend",
+    author_email="dan@dantownsend.co.uk",
+    python_requires=">=3.7.0",
+    url="https://github.com/piccolo-orm/piccolo_admin",
+    packages=find_packages(exclude=("tests",)),
     install_requires=REQUIREMENTS,
-    license='MIT',
+    extras_require={"faker": ["faker==6.5.0"]},
+    license="MIT",
     include_package_data=True,
     entry_points={
-        'console_scripts': [
-            'admin_demo = piccolo_admin.example:main',
-        ],
+        "console_scripts": ["admin_demo = piccolo_admin.example:main",],
     },
     classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: Implementation :: CPython',
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Database",
     ],
 )


### PR DESCRIPTION
Added an option to the `example.py` CLI, which will populate lots of extra data in the database.

```
# This will add 10,000 extra rows of data
python -m piccolo_admin.example --inflate=10000
```

This is really useful when testing the performance of the admin with large data sets.