### PR TITLE
add tooltip for table help text

### DIFF
--- a/admin_ui/src/components/Tooltip.vue
+++ b/admin_ui/src/components/Tooltip.vue
@@ -112,6 +112,7 @@ export default {
 span.tooltip {
     color: @light_blue;
     display: inline-block;
+    font-size: 0.9rem;
 
     div.popup {
         display: block;

--- a/admin_ui/src/views/RowListing.vue
+++ b/admin_ui/src/views/RowListing.vue
@@ -3,7 +3,15 @@
         <template v-if="schema != undefined">
             <div class="left_column">
                 <div class="title_bar">
-                    <h1>{{ tableName | readable }}</h1>
+                    <div class="title">
+                        <h1>
+                            {{ tableName | readable }}
+                        </h1>
+                        <Tooltip
+                            v-if="schema.help_text"
+                            :content="schema.help_text"
+                        />
+                    </div>
                     <div class="buttons">
                         <BulkDeleteButton
                             :selected="selectedRows.length"
@@ -231,6 +239,7 @@ import Pagination from "../components/Pagination.vue"
 import RowFilter from "../components/RowFilter.vue"
 import RowSortModal from "../components/RowSortModal.vue"
 import TableNav from "../components/TableNav.vue"
+import Tooltip from "../components/Tooltip.vue"
 
 export default Vue.extend({
     props: ["tableName"],
@@ -256,6 +265,7 @@ export default Vue.extend({
         RowFilter,
         RowSortModal,
         TableNav,
+        Tooltip,
     },
     computed: {
         cellNames() {
@@ -405,10 +415,16 @@ div.wrapper {
             flex-direction: column;
         }
 
-        h1 {
-            text-transform: capitalize;
-            margin: 0 0.5rem 0 0;
+        div.title {
             flex-grow: 1;
+            display: flex;
+            align-items: center;
+
+            h1 {
+                display: inline-block;
+                text-transform: capitalize;
+                margin: 0 0.5rem 0 0;
+            }
         }
 
         p {

--- a/docs/source/help_text/index.rst
+++ b/docs/source/help_text/index.rst
@@ -3,6 +3,9 @@
 Help Text
 =========
 
+Columns
+-------
+
 Sometimes you will want to provide hints to your users about what the form
 fields mean.
 
@@ -34,3 +37,21 @@ It isn't immediately clear what ``box_office`` means. We can add a
 
 
 Piccolo Admin will then show a tooltip next to this field.
+
+Tables
+------
+
+You can also provide help text about the table itself.
+
+.. code-block:: python
+
+    from piccolo.table import Table
+    from piccolo.columns import Varchar, Numeric
+
+
+    class Movie(Table, help_text="Movies which were released in the cinema."):
+        name = Varchar(length=300)
+        box_office = Numeric(digits=(5, 1), help_text="In millions of US dollars.")
+
+Piccolo Admin will then show a tooltip next to the table name in the row listing
+page.

--- a/piccolo_admin/example.py
+++ b/piccolo_admin/example.py
@@ -44,7 +44,7 @@ class User(BaseUser, tablename="piccolo_user"):
     pass
 
 
-class Director(Table):
+class Director(Table, help_text="The main director for a movie."):
     name = Varchar(length=300, null=False)
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-piccolo>=0.17.3
-piccolo_api>=0.12.11
+piccolo>=0.17.4
+piccolo_api>=0.12.12
 uvicorn
 aiofiles>=0.5.0
 Hypercorn


### PR DESCRIPTION
If a `Table` has the `help_text` attribute, show it as a tooltip in the UI.