### PR TITLE
Add custom Swagger UI from piccolo_api

### DIFF
--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -11,6 +11,7 @@ from piccolo.apps.user.tables import BaseUser
 from piccolo_api.csrf.middleware import CSRFMiddleware
 from piccolo_api.crud.endpoints import PiccoloCRUD
 from piccolo_api.fastapi.endpoints import FastAPIWrapper, FastAPIKwargs
+from piccolo_api.openapi.endpoints import swagger_ui
 from piccolo_api.rate_limiting.middleware import (
     RateLimitingMiddleware,
     RateLimitProvider,
@@ -87,7 +88,8 @@ class AdminRouter(FastAPI):
 
         #######################################################################
 
-        api_app = FastAPI()
+        api_app = FastAPI(docs_url=None)
+        api_app.add_route("/docs/", swagger_ui(schema_url="../openapi.json"))
 
         for table in tables:
             FastAPIWrapper(

--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -89,7 +89,7 @@ class AdminRouter(FastAPI):
         #######################################################################
 
         api_app = FastAPI(docs_url=None)
-        api_app.add_route("/docs/", swagger_ui(schema_url="../openapi.json"))
+        api_app.mount("/docs/", swagger_ui(schema_url="../openapi.json"))
 
         for table in tables:
             FastAPIWrapper(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 piccolo>=0.20.0
-piccolo_api>=0.15.0
+piccolo_api>=0.17.0
 uvicorn
 aiofiles>=0.5.0
 Hypercorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 piccolo>=0.20.0
-piccolo_api>=0.17.0
+piccolo_api>=0.17.1
 uvicorn
 aiofiles>=0.5.0
 Hypercorn


### PR DESCRIPTION
The Swagger docs in the Piccolo admin should now work with POST requests (Piccolo's CSRF middleware used to block it).