### PR TITLE
fix bug with description not being optional

### DIFF
--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -111,7 +111,7 @@ class FormConfig:
 class FormConfigResponseModel(BaseModel):
     name: str
     slug: str
-    description: str
+    description: t.Optional[str] = None
 
 
 def handle_auth_exception(request: Request, exc: Exception):


### PR DESCRIPTION
This was my mistake - the form will fail if the description is None.