### PR TITLE
fix font family

### DIFF
--- a/admin_ui/src/main.less
+++ b/admin_ui/src/main.less
@@ -10,9 +10,12 @@ body {
     min-height: 100%;
     margin: 0;
     position: relative;
-    font-family: 'Avenir', Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+body, textarea, button {
+    font-family: 'Avenir', Helvetica, Arial, sans-serif;
 }
 
 .light_mode {
@@ -182,7 +185,7 @@ input[type='password'],
 select,
 textarea {
     box-sizing: border-box;
-    font-size: 0.8rem;
+    font-size: 0.9rem;
     padding: 0.5rem;
     margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
I only realised today that `font-family` in CSS doesn't automatically apply to `button` or `textarea` elements.

This PR adds this, and increases the font size slightly.