### PR TITLE
fixing z-index for modal and dropdown menu

### DIFF
--- a/admin_ui/src/components/DropDownMenu.vue
+++ b/admin_ui/src/components/DropDownMenu.vue
@@ -23,7 +23,7 @@ ul {
     right: 0;
     width: 15rem;
     margin-top: 0.5rem;
-    z-index: 100;
+    z-index: 2000;
 
     li {
         margin: 0 !important;

--- a/admin_ui/src/components/Modal.vue
+++ b/admin_ui/src/components/Modal.vue
@@ -25,9 +25,9 @@ export default {
     props: {
         title: {
             type: String,
-            default: "",
-        },
-    },
+            default: ""
+        }
+    }
 }
 </script>
 
@@ -40,6 +40,7 @@ div#overlay {
     right: 0;
     background-color: rgba(0, 0, 0, 0.7);
     overflow: auto;
+    z-index: 2000;
 
     div.modal {
         border-radius: 0.5rem;


### PR DESCRIPTION
Small `z-index` fix for modal and dropdown menu.

Before:

![bad](https://user-images.githubusercontent.com/30960668/147257515-5e4b9b84-f5e6-471f-9b7b-e4c39dc17180.png)

After:

![good](https://user-images.githubusercontent.com/30960668/147257559-80aa8cbe-1711-4a4d-8eba-f8482de19a97.png)

