### PR TITLE
using literal includes for large code snippets

### DIFF
--- a/docs/source/asgi/examples/fastapi/app.py
+++ b/docs/source/asgi/examples/fastapi/app.py
@@ -1,0 +1,35 @@
+# app.py
+from fastapi import FastAPI
+from fastapi.routing import Mount
+from movies.tables import Director, Movie
+from piccolo.engine import engine_finder
+
+from piccolo_admin.endpoints import create_admin
+
+app = FastAPI(
+    routes=[
+        Mount(
+            "/admin/",
+            create_admin(
+                tables=[Director, Movie],
+                # Specify a different site name in the
+                # admin UI (default Piccolo Admin)
+                site_name="My Site Admin",
+                # Required when running under HTTPS:
+                # allowed_hosts=['my_site.com']
+            ),
+        ),
+    ],
+)
+
+
+@app.on_event("startup")
+async def open_database_connection_pool():
+    engine = engine_finder()
+    await engine.start_connnection_pool()
+
+
+@app.on_event("shutdown")
+async def close_database_connection_pool():
+    engine = engine_finder()
+    await engine.close_connnection_pool()

--- a/docs/source/asgi/examples/fastapi/movies/endpoints.py
+++ b/docs/source/asgi/examples/fastapi/movies/endpoints.py
@@ -1,0 +1,7 @@
+from starlette.endpoints import HTTPEndpoint
+from starlette.responses import HTMLResponse
+
+
+class HomeEndpoint(HTTPEndpoint):
+    async def get(request):
+        return HTMLResponse("<p>Movies</p>")

--- a/docs/source/asgi/examples/fastapi/movies/tables.py
+++ b/docs/source/asgi/examples/fastapi/movies/tables.py
@@ -1,0 +1,11 @@
+from piccolo.columns.column_types import ForeignKey, Varchar
+from piccolo.table import Table
+
+
+class Director(Table):
+    name = Varchar()
+
+
+class Movie(Table):
+    title = Varchar()
+    director = ForeignKey(Director)

--- a/docs/source/asgi/examples/starlette/app.py
+++ b/docs/source/asgi/examples/starlette/app.py
@@ -1,0 +1,22 @@
+import uvicorn
+from movies.endpoints import HomeEndpoint
+from movies.tables import Director, Movie
+from starlette.routing import Mount, Route, Router
+
+from piccolo_admin.endpoints import create_admin
+
+# The `allowed_hosts` argument is required when running under HTTPS. It's
+# used for additional CSRF defence.
+admin = create_admin([Director, Movie], allowed_hosts=["my_site.com"])
+
+
+router = Router(
+    [
+        Route(path="/", endpoint=HomeEndpoint),
+        Mount(path="/admin/", app=admin),
+    ]
+)
+
+
+if __name__ == "__main__":
+    uvicorn.run(router)

--- a/docs/source/asgi/examples/starlette/movies/endpoints.py
+++ b/docs/source/asgi/examples/starlette/movies/endpoints.py
@@ -1,0 +1,7 @@
+from starlette.endpoints import HTTPEndpoint
+from starlette.responses import HTMLResponse
+
+
+class HomeEndpoint(HTTPEndpoint):
+    async def get(request):
+        return HTMLResponse("<p>Movies</p>")

--- a/docs/source/asgi/examples/starlette/movies/tables.py
+++ b/docs/source/asgi/examples/starlette/movies/tables.py
@@ -1,0 +1,11 @@
+from piccolo.columns.column_types import ForeignKey, Varchar
+from piccolo.table import Table
+
+
+class Director(Table):
+    name = Varchar()
+
+
+class Movie(Table):
+    title = Varchar()
+    director = ForeignKey(Director)

--- a/docs/source/asgi/index.rst
+++ b/docs/source/asgi/index.rst
@@ -10,28 +10,7 @@ larger ASGI app.
 
 For example, using Starlette routes:
 
-.. code-block:: python
-
-    from piccolo_admin.endpoints import create_admin
-    from starlette.routing import Router, Route, Mount
-    import uvicorn
-
-    from my_project.tables import Director, Movie
-
-
-    # The `allowed_hosts` argument is required when running under HTTPS. It's
-    # used for additional CSRF defence.
-    admin = create_admin([Director, Movie], allowed_hosts=['my_site.com'])
-
-
-    router = Router([
-        Route(path="/", endpoint=Hello),
-        Mount(path="/admin/", app=admin),
-    ])
-
-
-    if __name__ == '__main__':
-        uvicorn.run(router)
+.. literalinclude:: ./examples/starlette/app.py
 
 -------------------------------------------------------------------------------
 
@@ -40,41 +19,7 @@ FastAPI example
 
 Here's a complete example of a FastAPI app using Piccolo admin.
 
-.. code-block:: python
-
-    # app.py
-    from fastapi import FastAPI
-    from piccolo.engine import engine_finder
-    from piccolo_admin.endpoints import create_admin
-    from starlette.routing import Mount
-    from my_project.tables import Director, Movie
-
-    app = FastAPI(
-        routes=[
-            Mount(
-                "/admin/",
-                create_admin(
-                    tables=[Director, Movie],
-                    # Specify a different site name in the
-                    # admin UI (default Piccolo Admin)
-                    site_name = "My Site Admin",
-                    # Required when running under HTTPS:
-                    # allowed_hosts=['my_site.com']
-                ),
-            ),
-        ],
-    )
-
-    @app.on_event("startup")
-    async def open_database_connection_pool():
-        engine = engine_finder()
-        await engine.start_connnection_pool()
-
-
-    @app.on_event("shutdown")
-    async def close_database_connection_pool():
-        engine = engine_finder()
-        await engine.close_connnection_pool()
+.. literalinclude:: ./examples/fastapi/app.py
 
 To run ``app.py`` use:
 

--- a/docs/source/custom_forms/examples/app.py
+++ b/docs/source/custom_forms/examples/app.py
@@ -1,0 +1,57 @@
+import smtplib
+
+from fastapi import FastAPI
+from fastapi.routing import Mount
+from home.tables import Task
+from pydantic import BaseModel
+
+from piccolo_admin.endpoints import FormConfig, create_admin
+
+
+# Pydantic model for form
+class EmailFormModel(BaseModel):
+    email: str
+    title: str
+    content: str
+
+
+# Send email handler
+def email_endpoint(request, data):
+    sender = "info@example.com"
+    receivers = data.email
+
+    message = f"""From: Sender <info@example.com>
+    To: Receiver <{data.email}>
+    Subject: {data.title}
+    {data.content}
+    """
+
+    try:
+        smtpObj = smtplib.SMTP("localhost:1025")
+        smtpObj.sendmail(sender, receivers, message)
+        print("Successfully sent email")
+    except smtplib.SMTPException:
+        print("Error: unable to send email")
+
+    return "Email sent"
+
+
+app = FastAPI(
+    routes=[
+        Mount(
+            "/admin/",
+            create_admin(
+                tables=[Task],
+                forms=[
+                    FormConfig(
+                        name="Business Email Form",
+                        pydantic_model=EmailFormModel,
+                        endpoint=email_endpoint,
+                    ),
+                ],
+            ),
+        ),
+    ],
+)
+
+# For Starlette it is identical, just `app = Starlette(...)`

--- a/docs/source/custom_forms/examples/home/tables.py
+++ b/docs/source/custom_forms/examples/home/tables.py
@@ -1,0 +1,6 @@
+from piccolo.columns.column_types import Varchar
+from piccolo.table import Table
+
+
+class Task(Table):
+    title = Varchar()

--- a/docs/source/custom_forms/index.rst
+++ b/docs/source/custom_forms/index.rst
@@ -8,68 +8,7 @@ without writing any frontend code.
 
 Here's an example of a form which sends email, using FastAPI:
 
-.. code-block:: python
-
-    import smtplib
-
-    from fastapi import FastAPI
-    from piccolo_admin.endpoints import (
-        create_admin,
-        FormConfig,
-    )
-    from pydantic import BaseModel
-
-    from home.tables import Task
-
-
-    # Pydantic model for form
-    class EmailFormModel(BaseModel):
-        email: str
-        title: str
-        content: str
-
-
-    # Send email handler
-    def email_endpoint(request, data):
-        sender = "info@example.com"
-        receivers = data.email
-
-        message = f"""From: Sender <info@example.com>
-        To: Receiver <{data.email}>
-        Subject: {data.title}
-        {data.content}
-        """
-
-        try:
-            smtpObj = smtplib.SMTP("localhost:1025")
-            smtpObj.sendmail(sender, receivers, message)
-            print("Successfully sent email")
-        except smtplib.SMTPException:
-            print("Error: unable to send email")
-
-        return "Email sent"
-
-
-    app = FastAPI(
-        routes=[
-            Mount(
-                "/admin/",
-                create_admin(
-                    tables=[Task],
-                    forms=[
-                        FormConfig(
-                            name="Business Email Form",
-                            pydantic_model=EmailFormModel,
-                            endpoint=email_endpoint,
-                        ),
-                    ],
-                ),
-            ),
-        ],
-    )
-
-    # For Starlette it is identical, just `app = Starlette(...)`
-
+.. literalinclude:: ./examples/app.py
 
 Piccolo Admin will then show a custom form in the UI.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
-Welcome to Piccolo Admin's documentation
-========================================
+Piccolo Admin
+=============
 
 `Piccolo Admin <https://github.com/piccolo-orm/piccolo_admin>`_ provides a
 simple yet powerful admin interface on top of Piccolo tables - allowing you to

--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -1,7 +1,7 @@
 """
 Creates a basic wrapper around a Piccolo model, turning it into an ASGI app.
 """
-from __future__ import annotations
+# from __future__ import annotations
 
 import inspect
 import json
@@ -13,7 +13,9 @@ from functools import partial
 
 from fastapi import FastAPI
 from piccolo.apps.user.tables import BaseUser
+from piccolo.columns.base import Column
 from piccolo.columns.reference import LazyTableReference
+from piccolo.table import Table
 from piccolo_api.crud.endpoints import PiccoloCRUD
 from piccolo_api.csrf.middleware import CSRFMiddleware
 from piccolo_api.fastapi.endpoints import FastAPIKwargs, FastAPIWrapper
@@ -34,11 +36,6 @@ from starlette.responses import HTMLResponse, JSONResponse
 from starlette.staticfiles import StaticFiles
 
 from .version import __VERSION__ as PICCOLO_ADMIN_VERSION
-
-if t.TYPE_CHECKING:  # pragma: no cover
-    from piccolo.columns.base import Column
-    from piccolo.table import Table
-
 
 ASSET_PATH = os.path.join(os.path.dirname(__file__), "dist")
 
@@ -160,6 +157,7 @@ class FormConfig:
         class MyModel(pydantic.BaseModel):
             message: str = "hello world"
 
+
         def my_endpoint(request: Request, data: MyModel):
             print(f"I received {data.message}")
 
@@ -170,6 +168,7 @@ class FormConfig:
             # If we're happy with the data, just return a string, which
             # will be displayed in the UI.
             return "Successful."
+
 
         config = FormConfig(
             name="My Form",


### PR DESCRIPTION
Rather than having large code snippets written inline within the docs, it's better to embed actual Python files because they can be tested and linted.