### PR TITLE
exposing `PiccoloCRUD`'s hooks

### DIFF
--- a/docs/source/table_config/index.rst
+++ b/docs/source/table_config/index.rst
@@ -124,6 +124,9 @@ Can be used to run custom logic when a row is created, modified, or deleted.
 
     create_admin([Director, movie_config])
 
+To learn more about hooks, see the :class:`Hook <piccolo_api.crud.hooks.Hook>`
+docs in Piccolo API.
+
 -------------------------------------------------------------------------------
 
 Source

--- a/docs/source/table_config/index.rst
+++ b/docs/source/table_config/index.rst
@@ -99,6 +99,33 @@ without having to write HTML.
 
 -------------------------------------------------------------------------------
 
+hooks
+-----
+
+Can be used to run custom logic when a row is created, modified, or deleted.
+
+.. code-block:: python
+
+    from piccolo_admin.endpoints import TableConfig
+    from piccolo_api.crud.hooks import Hook, HookType
+
+
+    async def my_save_hook(row: Movie):
+        # Insert custom logic here
+        return row
+
+
+    movie_config = TableConfig(
+        Movie,
+        hooks=[
+            Hook(hook_type=HookType.pre_save, callable=my_save_hook)
+        ]
+    )
+
+    create_admin([Director, movie_config])
+
+-------------------------------------------------------------------------------
+
 Source
 ------
 

--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -19,6 +19,7 @@ from piccolo.table import Table
 from piccolo.utils.warnings import Level, colored_warning
 from piccolo_api.change_password.endpoints import change_password
 from piccolo_api.crud.endpoints import PiccoloCRUD
+from piccolo_api.crud.hooks import Hook
 from piccolo_api.crud.validators import Validators
 from piccolo_api.csrf.middleware import CSRFMiddleware
 from piccolo_api.fastapi.endpoints import FastAPIKwargs, FastAPIWrapper
@@ -79,6 +80,11 @@ class TableConfig:
         on certain Piccolo :class:`Text <piccolo.columns.column_types.Text>`
         columns. Any columns not specified will use a standard HTML textarea
         tag in the UI.
+    :param hooks:
+        These are passed directly to
+        :class:`PiccoloCRUD <piccolo_api.crud.endpoints>`, which powers Piccolo
+        Admin under the hood. It allows you to run custom logic when a row
+        is modified.
 
     """
 
@@ -88,6 +94,7 @@ class TableConfig:
     visible_filters: t.Optional[t.List[Column]] = None
     exclude_visible_filters: t.Optional[t.List[Column]] = None
     rich_text_columns: t.Optional[t.List[Column]] = None
+    hooks: t.Optional[t.List[Hook]] = None
 
     def __post_init__(self):
         if self.visible_columns and self.exclude_visible_columns:
@@ -329,6 +336,7 @@ class AdminRouter(FastAPI):
                         "rich_text_columns": rich_text_columns_names,
                     },
                     validators=validators,
+                    hooks=table_config.hooks,
                 ),
                 fastapi_kwargs=FastAPIKwargs(
                     all_routes={

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,4 +1,6 @@
+import datetime
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from piccolo.apps.user.tables import BaseUser
 from piccolo.columns.column_types import (
@@ -8,11 +10,12 @@ from piccolo.columns.column_types import (
     Timestamp,
     Varchar,
 )
-from piccolo.table import Table
+from piccolo.table import Table, create_db_tables_sync, drop_db_tables_sync
+from piccolo_api.crud.hooks import Hook, HookType
 from piccolo_api.session_auth.tables import SessionsBase
 from starlette.testclient import TestClient
 
-from piccolo_admin.endpoints import TableConfig, get_all_tables
+from piccolo_admin.endpoints import TableConfig, create_admin, get_all_tables
 from piccolo_admin.example import APP
 from piccolo_admin.version import __VERSION__
 
@@ -138,11 +141,10 @@ class TestForms(TestCase):
     credentials = {"username": "Bob", "password": "bob123"}
 
     def setUp(self):
-        SessionsBase.create_table(if_not_exists=True).run_sync()
-        BaseUser.create_table(if_not_exists=True).run_sync()
-        BaseUser(
+        create_db_tables_sync(SessionsBase, BaseUser, if_not_exists=True)
+        BaseUser.create_user_sync(
             **self.credentials, active=True, admin=True, superuser=True
-        ).save().run_sync()
+        )
 
     def tearDown(self):
         SessionsBase.alter().drop_table().run_sync()
@@ -316,15 +318,13 @@ class TestTables(TestCase):
     credentials = {"username": "Bob", "password": "bob123"}
 
     def setUp(self):
-        SessionsBase.create_table(if_not_exists=True).run_sync()
-        BaseUser.create_table(if_not_exists=True).run_sync()
-        BaseUser(
+        create_db_tables_sync(SessionsBase, BaseUser, if_not_exists=True)
+        BaseUser.create_user_sync(
             **self.credentials, active=True, admin=True, superuser=True
-        ).save().run_sync()
+        )
 
     def tearDown(self):
-        SessionsBase.alter().drop_table().run_sync()
-        BaseUser.alter().drop_table().run_sync()
+        drop_db_tables_sync(SessionsBase, BaseUser)
 
     def test_tables(self):
         """
@@ -381,3 +381,76 @@ class TestTables(TestCase):
             response.json(),
             {"username": "Bob", "user_id": "1"},
         )
+
+
+class TestHooks(TestCase):
+
+    credentials = {"username": "Bob", "password": "bob123"}
+
+    def setUp(self):
+        create_db_tables_sync(SessionsBase, BaseUser, Post, if_not_exists=True)
+        BaseUser.create_user_sync(
+            **self.credentials, active=True, admin=True, superuser=True
+        )
+
+    def tearDown(self):
+        drop_db_tables_sync(SessionsBase, BaseUser, Post)
+
+    def test_hooks(self):
+        """
+        If a hook is passed to ``TableConfig``, make sure it gets called.
+        """
+        mock = MagicMock()
+
+        def hook(row, mock: MagicMock = mock):
+            mock()
+            row.name = "New Post 1"
+            return row
+
+        app = create_admin(
+            tables=[
+                TableConfig(
+                    table_class=Post,
+                    hooks=[Hook(hook_type=HookType.pre_save, callable=hook)],
+                )
+            ]
+        )
+
+        client = TestClient(app)
+
+        # To get a CSRF cookie
+        response = client.get("/")
+        csrftoken = response.cookies["csrftoken"]
+
+        # Login
+        payload = dict(csrftoken=csrftoken, **self.credentials)
+        client.post(
+            "/auth/login/",
+            json=payload,
+            headers={"X-CSRFToken": csrftoken},
+        )
+
+        # Now try creating a new row
+        response = client.post(
+            "/api/tables/post/",
+            json={
+                "name": "New Post",
+                "content": "Some content",
+                "rating": 100,
+                "created": datetime.datetime.now().isoformat(),
+            },
+            headers={"X-CSRFToken": csrftoken},
+        )
+        self.assertEqual(response.status_code, 201)
+
+        # Make sure the row is created with the correct data (the hook modified
+        # the name attribute).
+        self.assertFalse(
+            Post.exists().where(Post.name == "New Post").run_sync()
+        )
+        self.assertTrue(
+            Post.exists().where(Post.name == "New Post 1").run_sync()
+        )
+
+        # Make sure the hook was only called once.
+        mock.assert_called_once()


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo_admin/issues/179

Allows users to run custom logic when a row is creating / deleted / modified.