### PR TITLE
Fixed exclude_visible_columns for TableConfig

### DIFF
--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -199,7 +199,7 @@ class TableConfig:
             return include_columns
 
         if exclude_columns and not include_columns:
-            column_names = (i._meta.name for i in exclude_columns)
+            column_names = [i._meta.name for i in exclude_columns]
             return [i for i in all_columns if i._meta.name not in column_names]
 
         return all_columns

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -73,6 +73,16 @@ class TestTableConfig(TestCase):
             ("content", "created", "rating"),
         )
 
+    def test_exclude_visible_columns_without_pk(self):
+        post_table = TableConfig(
+            table_class=Post,
+            exclude_visible_columns=[Post.name],
+        )
+        self.assertEqual(
+            tuple(i._meta.name for i in post_table.get_visible_columns()),
+            ("id", "content", "created", "rating"),
+        )
+
     def test_visible_exclude_columns_error(self):
         with self.assertRaises(ValueError):
             post_table = TableConfig(


### PR DESCRIPTION
### What?

Fix for issue with `exclude_visible_columns` for `TableConfig`.

### Why?

Right now `exclude_visible_columns` parameter is not working if the primary key column is not in the list of excluded columns.  This PR introduces a possible quick fix for that problem.