### PR TITLE
allow `BaseUser` subclass to be used, which uses a `UUID` primary key

### DIFF
--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -776,7 +776,7 @@ class AdminRouter(FastAPI):
     def get_user(self, request: Request) -> UserResponseModel:
         return UserResponseModel(
             username=request.user.display_name,
-            user_id=request.user.user_id,
+            user_id=str(request.user.user_id),
         )
 
     ###########################################################################


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo_admin/issues/262