### PR TITLE
improve nullable JSON fields in Piccolo Admin

### DIFF
--- a/admin_ui/src/components/InputField.vue
+++ b/admin_ui/src/components/InputField.vue
@@ -96,6 +96,7 @@
                     ref="textarea"
                     v-bind:name="columnName"
                     v-bind:style="{ height: textareaHeight }"
+                    v-bind:placeholder="placeholder"
                     v-on:keyup="setTextareaHeight"
                 />
             </div>

--- a/admin_ui/src/utils.ts
+++ b/admin_ui/src/utils.ts
@@ -119,6 +119,12 @@ export function convertFormValue(params: {
     } else if (schema?.properties[key].type == "number" && value == "") {
         value = null
     } else if (
+        schema?.properties[key].format == "json" &&
+        schema?.properties[key].nullable &&
+        value == ""
+    ) {
+        value = null
+    } else if (
         schema?.properties[key].extra.foreign_key == true &&
         value == ""
     ) {

--- a/e2e/test_null_columns.py
+++ b/e2e/test_null_columns.py
@@ -31,5 +31,6 @@ def test_add_nullable_columns(page: Page, dev_server):
             "email": None,
             "timestamp": None,
             "date": None,
+            "json_": None,
         }
     ]

--- a/piccolo_admin/example.py
+++ b/piccolo_admin/example.py
@@ -245,6 +245,7 @@ class NullableColumns(Table):
     email = Email(null=True, default=None)
     timestamp = Timestamp(null=True, default=None)
     date = Date(null=True, default=None)
+    json_ = JSON(null=True, default=None)
 
 
 class SortedColumns(Table):


### PR DESCRIPTION
If you have a nullable JSON / JSONB column in Piccolo Admin, when you try saving it you would get a validation error.

For now, I'm assuming that if a JSON column is nullable, and the value is empty, then treat it as NULL instead of an empty string, as that's probably the intention.