### PR TITLE
More aggressive rate limiting

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: "Setup Node"
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
       - name: "Install all dependencies"
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
                   python-version: 3.11
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 16
             - name: "Install dependencies"
               run: |
                   pip install -r requirements/dev-requirements.txt

--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -656,7 +656,7 @@ class AdminRouter(FastAPI):
 
         if not rate_limit_provider:
             rate_limit_provider = InMemoryLimitProvider(
-                limit=1000, timespan=300
+                limit=100, timespan=300
             )
 
         public_app.mount(


### PR DESCRIPTION
By default, we're going to rate limit more aggressively - the user can always override this behaviour if they choose via the `rate_limit_provider` argument of `create_piccolo_admin`.