### PR TITLE
339: Fix nullable boolean columns in filter sidebar

### DIFF
--- a/admin_ui/src/components/FilterForm.vue
+++ b/admin_ui/src/components/FilterForm.vue
@@ -74,7 +74,8 @@ export default defineComponent({
     methods: {
         getValue(columnName: string) {
             if (
-                (this.schema as Schema).properties[columnName].type == "boolean"
+                getType((this.schema as Schema).properties[columnName]) ==
+                "boolean"
             ) {
                 return "all"
             } else {

--- a/admin_ui/src/views/RowListing.vue
+++ b/admin_ui/src/views/RowListing.vue
@@ -54,6 +54,7 @@
                             class="button"
                             href="#"
                             v-on:click.prevent="showFilter = !showFilter"
+                            data-uitest="filter_button"
                         >
                             <font-awesome-icon icon="filter" />
                             <span>
@@ -357,7 +358,11 @@
                 </div>
             </div>
 
-            <div class="right_column" v-if="showFilter">
+            <div
+                class="right_column"
+                v-if="showFilter"
+                data-uitest="right_sidebar"
+            >
                 <RowFilter
                     :showFilterSidebar="showFilter"
                     @closeSideBar="closeSideBar"

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -28,7 +28,7 @@ def context(context):
     # become available.
     # By default it's 30 seconds, which is way too long when testing an app
     # locally.
-    context.set_default_timeout(5000)
+    context.set_default_timeout(10000)
     yield context
 
 

--- a/e2e/pages.py
+++ b/e2e/pages.py
@@ -127,18 +127,42 @@ class SortModal:
             column_select.select_option(order_by.column._meta.name)
 
 
+class FilterSidebar:
+    """
+    Part of the :class:`RowListingPage`.
+    """
+
+    def __init__(self, page: Page):
+        self.sidebar = page.locator("div[data-uitest=right_sidebar]")
+
+    def get_input(self, name: str):
+        """
+        Returns the value of an input or select in the sidebar.
+
+        :param name:
+            The name of the input or select.
+
+        """
+        return self.sidebar.locator(f"[name={name}]")
+
+
 class RowListingPage:
     def __init__(self, page: Page, tablename: str):
         self.page = page
         self.url = f"{BASE_URL}/#/{tablename}"
         self.sort_button = page.locator("a[data-uitest=sort_button]")
+        self.filter_button = page.locator("a[data-uitest=filter_button]")
         self.sort_modal = SortModal(page=page)
+        self.filter_sidebar = FilterSidebar(page=page)
 
     def reset(self):
         self.page.goto(self.url)
 
     def open_sort_modal(self):
         self.sort_button.click()
+
+    def open_filter_sidebar(self):
+        self.filter_button.click()
 
 
 class EditRowPage:

--- a/e2e/test_null_columns.py
+++ b/e2e/test_null_columns.py
@@ -34,5 +34,6 @@ def test_add_nullable_columns(page: Page, dev_server):
             "json_": None,
             "varchar": None,
             "text": None,
+            "boolean": None
         }
     ]

--- a/e2e/test_null_columns.py
+++ b/e2e/test_null_columns.py
@@ -2,7 +2,7 @@ from playwright.sync_api import Page
 
 from piccolo_admin.example import NullableColumns
 
-from .pages import AddRowPage, LoginPage
+from .pages import AddRowPage, LoginPage, RowListingPage
 
 
 def test_add_nullable_columns(page: Page, dev_server):
@@ -34,6 +34,25 @@ def test_add_nullable_columns(page: Page, dev_server):
             "json_": None,
             "varchar": None,
             "text": None,
-            "boolean": None
+            "boolean": None,
         }
     ]
+
+
+def test_nullable_boolean_filter(page: Page, dev_server):
+    """
+    Make sure that nullable boolean columns in the filter sidebar default to
+    `all` and NOT `null`.
+    """
+    login_page = LoginPage(page=page)
+    login_page.reset()
+    login_page.login()
+
+    row_listing_page = RowListingPage(
+        page=page, tablename=NullableColumns._meta.tablename
+    )
+    row_listing_page.reset()
+    row_listing_page.open_filter_sidebar()
+
+    html_select = row_listing_page.filter_sidebar.get_input("boolean")
+    assert html_select.input_value() == "all"

--- a/piccolo_admin/example.py
+++ b/piccolo_admin/example.py
@@ -249,6 +249,7 @@ class NullableColumns(Table):
     json_ = JSON(null=True, default=None)
     text = Text(null=True, default=None)
     varchar = Varchar(null=True, default=None)
+    boolean = Boolean(null=True, default=None)
 
 
 class RequiredColumns(Table):

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,7 +1,7 @@
 pytest==7.4.2
 pytest-cov==4.1.0
 flake8==5.0.4
-piccolo[postgres,sqlite]>=0.30.0
-playwright==1.39.0
+piccolo[postgres,sqlite]>=1.0.0
+playwright==1.38.0
 pytest-playwright==0.4.3
 httpx>=0.20.0


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo_admin/issues/339

Remaining tasks:

- [x] Fix the code in the front end which checks whether the type is boolean
- [x] Add a new Playwright test to make sure the default value for nullable boolean fields in the filter sidebar is 'all'
- [x] Work out why the Playwright tests are failing intermittently (using Playwright 1.38.0 seems to help - we bumped it to 1.39.0 during the v1 release of Piccolo Admin, and that's when all the problems seemed to start)