### PR TITLE
disable unique column in BulkUpdate dropdown

### DIFF
--- a/admin_ui/src/components/BulkUpdateModal.vue
+++ b/admin_ui/src/components/BulkUpdateModal.vue
@@ -11,7 +11,10 @@
                     <option
                         :key="columnName"
                         :value="columnName"
-                        v-if="columnName != schema.extra.primary_key_name"
+                        v-if="
+                            columnName != schema.extra.primary_key_name &&
+                            property.extra.unique == false
+                        "
                     >
                         {{ property.title }}
                     </option>

--- a/admin_ui/src/interfaces.ts
+++ b/admin_ui/src/interfaces.ts
@@ -155,6 +155,7 @@ export interface PropertyExtra {
     help_text: string | null
     nullable: boolean
     secret: boolean
+    unique: boolean
     widget?: string
 }
 

--- a/e2e/test_codegen.py
+++ b/e2e/test_codegen.py
@@ -95,8 +95,6 @@ def test_bulk_update(playwright: Playwright, dev_server) -> None:
         "checkbox"
     ).check()
     page.get_by_role("link", name="Update 8 rows").click()
-    # Let Vue JS finish loading
-    page.wait_for_timeout(1000)
     page.locator('select[name="property"]').select_option("gender")
     page.locator('select[name="gender"]').select_option("f")
     page.get_by_role("button", name="Update").click()

--- a/e2e/test_codegen.py
+++ b/e2e/test_codegen.py
@@ -95,6 +95,8 @@ def test_bulk_update(playwright: Playwright, dev_server) -> None:
         "checkbox"
     ).check()
     page.get_by_role("link", name="Update 8 rows").click()
+    # Let Vue JS finish loading
+    page.wait_for_timeout(1000)
     page.locator('select[name="property"]').select_option("gender")
     page.locator('select[name="gender"]').select_option("f")
     page.get_by_role("button", name="Update").click()

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-piccolo>=1.1.0
+piccolo>=1.5.0
 piccolo_api>=1.1.0
 uvicorn
 aiofiles>=0.5.0


### PR DESCRIPTION
Related to this [issue](https://github.com/piccolo-orm/piccolo_api/issues/273). This PR will disable unique columns in bulk update. This change will work when a new version of Piccolo ORM is released. Playwright tests will also pass after new Piccolo ORM release, because for now `BulkUpdate` dropdown is empty