### PR TITLE
Update Codecov GitHub Action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,4 +66,4 @@ jobs:
             - name: Test with pytest, SQLite
               run: ./scripts/run-tests.sh
             - name: Upload coverage
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@v4


### PR DESCRIPTION
Out CI is currently blocked, because our coverage results can't be uploaded to codecov.io.

Try updating the Codecov GitHub Action to see if that helps.