### PR TITLE
Update contributing documentation for local backends

### DIFF
--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -23,6 +23,14 @@ It will auto refresh the UI as you make changes to the source files.
 The UI needs an API to interact with - the easiest way to do this is to use the
 demo app.
 
+If you are developing on a local copy, you will first need to build
+distribution files that the backend relies on.
+``cd`` into the ``admin_ui`` directory and run the following:
+
+.. code-block:: bash
+
+    npm run build
+
 .. code-block:: bash
 
     admin_demo

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -25,11 +25,14 @@ demo app.
 
 If you are developing on a local copy, you will first need to build
 distribution files that the backend relies on.
+
 ``cd`` into the ``admin_ui`` directory and run the following:
 
 .. code-block:: bash
 
     npm run build
+
+Then start the API:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The backend requires the project to be built for `dist` files to be in place. This PR just makes that a touch clearer