### PR TITLE
Fix Playwright and Linters in CI

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
     playwright:
         name: "Playwright Tests"
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: "Checkout repository"
               uses: "actions/checkout@v4"

--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -680,7 +680,7 @@ class AdminRouter(FastAPI):
 
         private_app.add_route(
             path="/change-password/",
-            route=change_password(
+            route=change_password(  # type: ignore
                 login_url="./../../public/login/",
                 session_table=session_table,
                 read_only=read_only,
@@ -786,7 +786,7 @@ class AdminRouter(FastAPI):
 
         public_app.add_route(
             path="/logout/",
-            route=session_logout(session_table=session_table),
+            route=session_logout(session_table=session_table),  # type: ignore
             methods=["POST"],
         )
 

--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -100,13 +100,13 @@ class GroupItem(BaseModel):
 
 
 class GroupedTableNamesResponseModel(BaseModel):
-    grouped: t.Dict[str, t.List[str]] = Field(default_factory=list)
+    grouped: t.Dict[str, t.List[str]] = Field(default_factory=dict)
     ungrouped: t.List[str] = Field(default_factory=list)
 
 
 class GroupedFormsResponseModel(BaseModel):
     grouped: t.Dict[str, t.List[FormConfigResponseModel]] = Field(
-        default_factory=list
+        default_factory=dict
     )
     ungrouped: t.List[FormConfigResponseModel] = Field(default_factory=list)
 

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,9 +4,5 @@ flake8==7.0.0
 piccolo[postgres,sqlite]>=1.16.0
 playwright==1.41.2
 pytest-playwright==0.4.4
-httpx>=0.20.0
-# This is needed because newer versions of FastAPI use a Starlette version with
-# a `TestClient` which breaks rate limiting.
-# The changes to `TestClient` will likely be reverted in a future release, in
-# which case we can remove this version pin.
-fastapi==0.106.0
+httpx==0.28.1
+fastapi==0.115.6


### PR DESCRIPTION
Pulling it out of this other PR, which was getting too large: https://github.com/piccolo-orm/piccolo_admin/pull/432

Playwright doesn't currently work in our CI, because of some missing dependencies in the latests Ubuntu LTS.

We also need to remove the version pin for FastAPI, because of some changes with Starlette's `TestClient`.