### PR TITLE
Be explicit with `create_admin` function and `tables=` that we're not creating them, but registering them

### DIFF
--- a/docs/source/asgi/examples/starlette/app.py
+++ b/docs/source/asgi/examples/starlette/app.py
@@ -7,7 +7,7 @@ from piccolo_admin.endpoints import create_admin
 
 # The `allowed_hosts` argument is required when running under HTTPS. It's
 # used for additional CSRF defence.
-admin = create_admin([Director, Movie], allowed_hosts=["my_site.com"])
+admin = create_admin(tables=[Director, Movie], allowed_hosts=["my_site.com"])
 
 
 router = Router(

--- a/piccolo_admin/endpoints.py
+++ b/piccolo_admin/endpoints.py
@@ -1201,7 +1201,8 @@ def create_admin(
 ):
     """
     :param tables:
-        Each of the tables will be added to the admin.
+        Each of the provided tables will be registered with the admin app and
+        editable/visible in the view. Tables must already exist (see Piccolo ORM).
     :param forms:
         For each :class:`FormConfig <piccolo_admin.endpoints.FormConfig>`
         specified, a form will automatically be rendered in the user interface,


### PR DESCRIPTION
A more exact overview of what adding tables to the `create_admin` function does for beginners. The particular wording can be different if you prefer, but "add" in my experience (as you're using migrations in `agsi new` for Piccolo ORM) can be confused with "create" (as in `create_db_tables`). Will also eventually slightly rewrite the "Getting started guide" for `agsi new` (will explain later).

1. Add named argument to example for clarity
2. Add endpoint docs for `tables=`

Fixes https://github.com/piccolo-orm/piccolo/issues/1276